### PR TITLE
Fix inlay hints crash in simrat39/rust-tools.nvim#300

### DIFF
--- a/lua/rust-tools/inlay_hints.lua
+++ b/lua/rust-tools/inlay_hints.lua
@@ -175,6 +175,14 @@ function M.cache_render(self, bufnr)
   end
 end
 
+local function parse_hint_label(hint_label)
+  if type(hint_label) == "string" then
+    return hint_label
+  elseif type(hint_label) == "table" then
+    return table.concat(vim.tbl_map(function (label_part) return label_part.value end, hint_label))
+  end
+end
+
 local function render_line(line, line_hints, bufnr)
   local opts = rt.config.options.tools.inlay_hints
   local virt_text = ""
@@ -189,11 +197,11 @@ local function render_line(line, line_hints, bufnr)
   -- segregate parameter hints and other hints
   for _, hint in ipairs(line_hints) do
     if hint.kind == 2 then
-      table.insert(param_hints, hint.label)
+      table.insert(param_hints, parse_hint_label(hint.label))
     end
 
     if hint.kind == 1 then
-      table.insert(other_hints, hint)
+      table.insert(other_hints, parse_hint_label(hint.label))
     end
   end
 
@@ -213,11 +221,7 @@ local function render_line(line, line_hints, bufnr)
   if not vim.tbl_isempty(other_hints) then
     virt_text = virt_text .. opts.other_hints_prefix
     for i, o_hint in ipairs(other_hints) do
-      if string.sub(o_hint.label, 1, 2) == ": " then
-        virt_text = virt_text .. o_hint.label:sub(3)
-      else
-        virt_text = virt_text .. o_hint.label
-      end
+      virt_text = virt_text .. o_hint:gsub("^: ", "")
       if i ~= #other_hints then
         virt_text = virt_text .. ", "
       end


### PR DESCRIPTION
According to LSP spec,
[InlayHint.label](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#inlayHint) can be either a string or an array. Previously, `rust-analyzer` was always returning strings. Most likely after
[this recent PR](https://github.com/rust-lang/rust-analyzer/pull/13699) it started returning arrays.

Based on my testing, it seems only inlay hints with `kind` 1 are returning arrays but I am preemptively handling `kind` 2 as well in case it changes in the future.